### PR TITLE
Allow vas logins through ssh and console 

### DIFF
--- a/vasd.te
+++ b/vasd.te
@@ -494,3 +494,16 @@ optional_policy(`
         dbus_connect_system_bus(vasd_t)
 ')
 
+# =============================================================
+# Allow sshd_t and local_login_t to access the vasd socket for 
+# authentication
+#
+# Same as:
+#      allow sshd_t initrc_t:unix_stream_socket connectto;
+#      allow local_login_t initrc_t:unix_stream_socket connectto;
+#
+# =============================================================
+ init_stream_connect_script(sshd_t)
+ init_stream_connect_script(local_login_t)
+ 
+

--- a/vasd.te
+++ b/vasd.te
@@ -1,4 +1,4 @@
-policy_module(vasd, 1.0.5)
+policy_module(vasd, 1.0.6)
 
 ########################################
 #
@@ -36,6 +36,11 @@ corecmd_executable_file( vasd_bin_t )
 
 type vasd_lib_t;
 files_type(vasd_lib_t)
+
+require{
+    type sshd_t;
+    type local_login_t;
+}
 
 ########################################
 #


### PR DESCRIPTION
This modification allows for sshd and systemd login to access the vasd socket for authentication